### PR TITLE
pull rebase fails because git branch --quiet is only in git > 1.8

### DIFF
--- a/git-hub
+++ b/git-hub
@@ -1340,7 +1340,7 @@ class RebaseCmd (PullUtil):
 			errfunc("Can't checkout '{}', maybe it was removed "
 				"during the rebase? {}",  old_ref, e)
 		if cls.branch_exists(tmp_ref):
-			git_quiet(1, 'branch', '-D', tmp_ref)
+			git(1, 'branch', '-D', tmp_ref)
 
 	# Performs the rebasing itself. Sets the `in_conflict` flag if
 	# a conflict is detected.


### PR DESCRIPTION
```
$ pwd
/home/dicebot/desktop/devel/sociomantic/git-hub
$ git status
# On branch master
nothing to commit (working directory clean)
$ git hub pull rebase 20
Fetching misc from git@github.com:leandro-lucarella-sociomantic/git-hub.git
Rebasing to master in git@github.com:sociomantic/git-hub.git
Pushing results to master in git@github.com:sociomantic/git-hub.git
Error: git branch --quiet -D git-hub-pull-rebase-20 failed (return code: 129)
error: unknown option `quiet'
```
