### PR TITLE
Fix temporary branch deletion broken by 30f3ffc

### DIFF
--- a/git-hub
+++ b/git-hub
@@ -1340,7 +1340,7 @@ class RebaseCmd (PullUtil):
 			errfunc("Can't checkout '{}', maybe it was removed "
 				"during the rebase? {}",  old_ref, e)
 		if cls.branch_exists(tmp_ref):
-			git(1, 'branch', '-D', tmp_ref)
+			git('branch', '-D', tmp_ref)
 
 	# Performs the rebasing itself. Sets the `in_conflict` flag if
 	# a conflict is detected.


### PR DESCRIPTION
While fixing a branch deletion problem when using older Git versions,
the git() call still had the position for the --quiet argument which is
only present int git_quiet().
