### PR TITLE
Require authentication info to use the hub clone command

### DIFF
--- a/git-hub
+++ b/git-hub
@@ -567,6 +567,7 @@ class SetupCmd (object):
 # `git hub clone` command implementation
 class CloneCmd (object):
 
+	cmd_required_config = ['username', 'urltype', 'upstream', 'oauthtoken']
 	cmd_help = 'clone a GitHub repository (and fork as needed)'
 
 	@classmethod


### PR DESCRIPTION
The `clone` command needs authentication to check if the user have forked the project already. A weird and uninformative error is presented if this doesn't happen, as shown by #30.
