### PR TITLE
Clone command ask for the hub.upstream config variable to be present

### DIFF
--- a/git-hub
+++ b/git-hub
@@ -567,7 +567,7 @@ class SetupCmd (object):
 # `git hub clone` command implementation
 class CloneCmd (object):
 
-	cmd_required_config = ['username', 'urltype', 'upstream', 'oauthtoken']
+	cmd_required_config = ['username', 'urltype', 'oauthtoken']
 	cmd_help = 'clone a GitHub repository (and fork as needed)'
 
 	@classmethod


### PR DESCRIPTION
The clone command is actually in charge of create that variable!
