### PR TITLE
--edit-msg not properly saved by pull rebase

### DIFF
--- a/git-hub
+++ b/git-hub
@@ -1434,7 +1434,7 @@ class RebaseCmd (PullUtil):
 					cls.saved_old_ref = f.readline()[:-1]
 					assert cls.saved_old_ref
 					edit_msg = f.readline()[:-1]
-					cls.saved_edit_msg = edit_msg is "True"
+					cls.saved_edit_msg = (edit_msg == "True")
 					msg = f.read()
 					if msg == '\n':
 						msg = ''


### PR DESCRIPTION
The `--edit-msg` flag is not properly saved by the pull rebase command, so if it gets interrupted because of a conflict, the original argument won't be used (the real problem is how the data is being read).
