### PR TITLE
pull rebase --pause message is not clear enough

### DIFF
--- a/git-hub
+++ b/git-hub
@@ -1378,8 +1378,9 @@ class RebaseCmd (PullUtil):
 			if args.pause and not cls.in_pause:
 				cls.in_pause = True
 				cls.create_rebasing_file(pull, args, old_ref)
-				interrupt('Rebase done, now pausing. '
-						'Use --continue when done.')
+				interrupt("Rebase done, now --pause'ing. "
+					'Use --continue {}when done.',
+					'' if starting else 'once more ')
 			cls.in_pause = False
 			infof('Pushing results to {} in {}',
 					base_ref, base_url)


### PR DESCRIPTION
Reported by @mihails-strasuns-sociomantic in #42:

---

When I do hit hub rebase --pause and there are rebase conflicts, next first "continue" succeeds only partially:

```
$ git hub pull rebase --continue 
Rebase done, now pausing. Use --continue when done.
$ git hub pull rebase --continue 
Pushing results to master in git@github.com:user/repo.git
[12345678] This pull request has been rebased via `git hub pull rebase`… (mihails-strasuns-sociomantic)
```
