### PR TITLE
git-hub --version has two "v"s

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ deb:
 man: git-hub.1
 
 git-hub.1: man.rst git-hub
-	sed 's/^:Version: devel$$/:Version: $(version)/' $< | \
+	sed 's/^:Version: devel$$/:Version: '"`git describe`"'/' $< | \
 		rst2man --exit-status=1 > $@ || ($(RM) $@ && false)
 
 bash-completion: generate-bash-completion git-hub


### PR DESCRIPTION
The version string contains two v's. Seems wrong to me?

```
backend git:(master) git-hub --version      
git-hub vv0.4
```
