### PR TITLE
Fix 'git hub pull checkout' typo

### DIFF
--- a/git-hub
+++ b/git-hub
@@ -1114,7 +1114,7 @@ class PullCmd (IssueCmd):
 			infof('Fetching {} from {}', remote_branch, remote_url)
 
 			git_quiet(1, 'fetch', remote_url, remote_branch)
-			git_quiet(1, 'checkout', 'FETCH_HEAD', *args.arg)
+			git_quiet(1, 'checkout', 'FETCH_HEAD', *args.args)
 
 # This class is top-level just for convenience, because is too big. Is added to
 # PullCmd after is completely defined!


### PR DESCRIPTION
'args.arg' -> 'args.args'
Looks like it was broken all this time since last merge (I was using 'rebase --pause' exsclusively in a while)
