### PR TITLE
Fix #54: Remove .git/HUB_PULL_REBASING after rebase -p

### DIFF
--- a/git-hub
+++ b/git-hub
@@ -1399,11 +1399,17 @@ class RebaseCmd (PullUtil):
 				cls.rebase(args, pull)
 			if args.pause and not cls.in_pause:
 				cls.in_pause = True
+				# Re-create the rebasing file as we are going
+				# to pause
 				cls.create_rebasing_file(pull, args, old_ref)
 				interrupt("Rebase done, now --pause'ing. "
 					'Use --continue {}when done.',
 					'' if starting else 'once more ')
-			cls.in_pause = False
+			# If we were paused, remove the rebasing file that we
+			# just re-created
+			if cls.in_pause:
+				cls.in_pause = False
+				cls.remove_rebasing_file()
 			infof('Pushing results to {} in {}',
 					base_ref, base_url)
 			git_push(base_url, 'HEAD:' + base_ref, force=args.force)


### PR DESCRIPTION
After a successful rebase --pause the file was not removed because the
original removal mechanism was done before the pause is done. To pause,
the file is re-created, but was never removed again. This commit fixes
this problem by just removing the re-created file too.
