### PR TITLE
Support GitHub Enterprise

### DIFF
--- a/git-hub
+++ b/git-hub
@@ -297,6 +297,27 @@ class Config:
 		self.forkremote = git_config('forkremote', 'origin')
 		self.pullbase = git_config('pullbase', 'master')
 		self.urltype = git_config('urltype', 'ssh_url')
+		self.baseurl = self.sanitize_url('baseurl',
+			git_config('baseurl', 'https://api.github.com'))
+
+	def sanitize_url(self, name, url):
+		from urlparse import urlsplit, urlunsplit
+		u = urlsplit(url)
+		name = GIT_CONFIG_PREFIX + name
+		# interpret www.github.com/api/v4 as www.github.com, /api/v4
+		if not u.hostname or not u.scheme:
+			die("Please provide a full URL for '{}' (e.g. "
+					"https://api.github.com), got {}",
+					name, url)
+		if u.username or u.password:
+			warnf("Username and password in '{}' ({}) will be "
+					"ignored, use the 'setup' command "
+					"for authentication", name, url)
+		netloc = u.hostname
+		if u.port:
+			netloc += ':' + u.port
+		return urlunsplit((u.scheme, netloc, u.path.rstrip('/'),
+				u.query, u.fragment))
 
 	def check(self, name):
 		if getattr(self, name) is None:
@@ -310,8 +331,8 @@ class Config:
 # The real interesting methods are created after the class declaration, for
 # each type of request: head(), get(), post(), patch(), put() and delete().
 #
-# All these methods take an URL (relative to the base_url) and optionally an
-# arbitrarily number of positional or keyword arguments (but not both at the
+# All these methods take an URL (relative to the config.baseurl) and optionally
+# an arbitrarily number of positional or keyword arguments (but not both at the
 # same time). The extra arguments, if present, are serialized as json and sent
 # as the request body.
 # All these methods return None if the response is empty, or the deserialized
@@ -329,7 +350,6 @@ class Config:
 # See http://developer.github.com/ for more details on the GitHub API
 class RequestManager:
 
-	base_url = 'https://api.github.com'
 	basic_auth = None
 
 	# Configure the class to use basic authentication instead of OAuth
@@ -341,7 +361,7 @@ class RequestManager:
 	# method. It also add other convenience headers, like Content-Type,
 	# Accept (both to json) and Content-Length).
 	def auth_urlopen(self, url, method, body):
-		req = urllib2.Request(self.base_url + url, body)
+		req = urllib2.Request(config.baseurl + url, body)
 		if self.basic_auth:
 			req.add_header("Authorization", self.basic_auth)
 		elif config.oauthtoken:
@@ -541,6 +561,9 @@ class SetupCmd (object):
 			help="GitHub's username (login name)")
 		parser.add_argument('-p', '--password',
 			help="GitHub's password (will not be stored)")
+		parser.add_argument('-b', '--baseurl', metavar='URL',
+			help="GitHub's base URL to use to access the API "
+			"(Enterprise servers usually use https://host/api/v3)")
 		group = parser.add_mutually_exclusive_group()
 		group.add_argument('--global',
 			dest='opts', action='store_const', const=['--global'],
@@ -577,6 +600,8 @@ class SetupCmd (object):
 		set_config = lambda k, v: git_config(k, value=v, opts=args.opts)
 		set_config('username', username)
 		set_config('oauthtoken', auth['token'])
+		if args.baseurl is not None:
+			set_config('baseurl', args.baseurl)
 
 
 # `git hub clone` command implementation

--- a/man.rst
+++ b/man.rst
@@ -43,7 +43,8 @@ COMMANDS
   asks GitHub for an authorization token and stores it in the configuration
   variable `hub.oauthtoken` for future use so you don't need to type your
   password each time (or store it in the config). The username is also stored
-  for future use in the `hub.username` variable.
+  for future use in the `hub.username` variable. If the base URL is specified,
+  it is stored in `hub.baseurl` too.
 
   \-u USERNAME, --username=USERNAME
     GitHub's username (login name), will be stored in the configuration
@@ -51,6 +52,11 @@ COMMANDS
 
   \-p PASSWORD, --password=PASSWORD
     GitHub's password (will not be stored).
+
+  \-b URL, --baseurl=URL
+    GitHub's base URL to use to access the API. Set this when you GitHub API is
+    in another location other than the default (Enterprise servers usually use
+    https://host/api/v3).
 
   \--global
     Store settings in the global configuration (see --global option in `git
@@ -362,6 +368,12 @@ from. These are the git config keys used:
   when 'pull rebase' is used). At the time of writing it could be *ssh_url*
   or *clone_url* for HTTP). See GitHub's API documentation[1] for more
   details or options. [default: *ssh_url*]
+
+`hub.baseurl`
+  GitHub's base URL to use to access the API. Set this when you GitHub API is
+  in another location other than the default (Enterprise servers usually use
+  https://host/api/v3). This will be prepended to all GitHub API calls and it
+  has to be a full URL, not just something like "www.example.com/api/v3/".
 
 [1] http://developer.github.com/v3/pulls/#get-a-single-pull-request
 


### PR DESCRIPTION
This issue was started by a [e-mail message by Ronnie Ridpath](http://librelist.com/browser//git.hub/2013/11/1/how-to-setup-with-github-enterprise/#4d0c4ad124b6f94b787aa2bead13c21e) sent to the mailing list.

Some steps that need to be made to make this happen:
- [x] Make `base_url` configurable
- [x] Validate `base_url` (make sure the URL is at least syntactically valid)
- [x] Make `RequestManager` able to handle a `base_url` that isn't at the root of the server (`http://example.com/api/v3` in particular)

Other changes might be needed.
