### PR TITLE
Add an option to add --force rebase while doing a pull rebase

### DIFF
--- a/git-hub
+++ b/git-hub
@@ -299,6 +299,8 @@ class Config:
 		self.urltype = git_config('urltype', 'ssh_url')
 		self.baseurl = self.sanitize_url('baseurl',
 			git_config('baseurl', 'https://api.github.com'))
+		self.forcerebase = git_config('forcerebase', "false",
+				opts=['--bool']) == "true"
 
 	def sanitize_url(self, name, url):
 		from urlparse import urlsplit, urlunsplit
@@ -1463,7 +1465,11 @@ class RebaseCmd (PullUtil):
 		starting = args.action is None
 		try:
 			if starting:
-				git_quiet(1, 'rebase', 'FETCH_HEAD')
+				a = []
+				if config.forcerebase:
+					a.append('--force')
+				a.append('FETCH_HEAD')
+				git_quiet(1, 'rebase', *a)
 			else:
 				git('rebase', args.action)
 		except subprocess.CalledProcessError as e:

--- a/man.rst
+++ b/man.rst
@@ -293,6 +293,15 @@ COMMANDS
     7. git branch -D `tmp`
     8. git pop
 
+    If `hub.forcerebase` is set to "yes" (the default), ``--force`` will be
+    passed to rebase (not to be confused with this command option
+    ``--force-push`` which will force the push), otherwise a regular rebase is
+    performed. When the rebase is forced, all the commits in the pull request
+    are re-committed, so the Committer and CommitterDate metadata is updated in
+    the commits, showing the person that performed the rebase and the time of
+    the rebase instead of the original values, so providing more useful
+    information. As a side effect, the hashes of the commits will change.
+
     If conflicts are found, the command is interrupted, similarly to how `git
     rebase` would do. The user should either **--abort** the rebasing,
     **--skip** the conflicting commit or resolve the conflict and
@@ -379,6 +388,11 @@ from. These are the git config keys used:
   in another location other than the default (Enterprise servers usually use
   https://host/api/v3). This will be prepended to all GitHub API calls and it
   has to be a full URL, not just something like "www.example.com/api/v3/".
+
+`hub.forcerebase`
+  If is set to "yes", ``--force`` will be passed to rebase. If is set to "no"
+  a regular rebase is performed. See the `pull` `rebase` command for detils.
+  [default: yes]
 
 [1] http://developer.github.com/v3/pulls/#get-a-single-pull-request
 


### PR DESCRIPTION
Adding --force to rebase makes the committer and commit date change, so information about who actually "merged" the changes to master doesn't get lost. The bad part is the hash for all the commits involved will change too. But that's always a possibility when rebasing, so it shouldn't be a big deal.
