### PR TITLE
`python` defaults to `python3` on arch, this could be a fix

### DIFF
--- a/git-hub
+++ b/git-hub
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # vim: set fileencoding=utf-8 :
 
 # Git command line interface to GitHub.


### PR DESCRIPTION
Possibly a fix for issue #73

This may brake the script for other users, but it is a fix for archlinux users. I'm not a python guy, but maybe you can do some workarounds based on this...
