### PR TITLE
Can't list issues for a repository without any

### DIFF
--- a/git-hub
+++ b/git-hub
@@ -794,6 +794,8 @@ class IssueCmd (CmdGroup):
 					return True
 			state = 'closed' if args.closed else 'open'
 			issues = req.get(cls.url(), state=state)
+			if not issues:
+				return
 			if args.created_by_me and args.assigned_to_me:
 				issues = [i for i in issues
 					if filter(i, 'assignee') or


### PR DESCRIPTION
Discovered by @abdu-almamou-sociomantic.

```
$ git hub issue list
Traceback (most recent call last):
  File "/home/luca/bin/git-hub", line 1683, in <module>
    main()
  File "/home/luca/bin/git-hub", line 1677, in main
    args.run(parser, args)
  File "/home/luca/bin/git-hub", line 578, in check_config_and_run
    cmd.run(parser, args)
  File "/home/luca/bin/git-hub", line 804, in run
    for issue in issues:
TypeError: 'NoneType' object is not iterable
```
