### PR TITLE
Use GitHub media type v3

### DIFF
--- a/git-hub
+++ b/git-hub
@@ -382,7 +382,7 @@ class RequestManager:
 			req.add_header("Authorization", "bearer " +
 					self.oauthtoken)
 		req.add_header("Content-Type", "application/json")
-		req.add_header("Accept", "application/json")
+		req.add_header("Accept", "application/vnd.github.beta+json")
 		req.add_header("Content-Length", str(len(body) if body else 0))
 		req.get_method = lambda: method.upper()
 		debugf('{}', req.get_full_url())


### PR DESCRIPTION
GitHub is changing the default media type used soon. The changes
compared to the current default (beta) are minimum and this tool
shouldn't be affected. Just to make sure we are using a fixed version
(which now is the latest), we explicitly ask for the
"application/vnd.github.v3+json" media type now.

For more details see:
https://developer.github.com/changes/2014-01-07-upcoming-change-to-default-media-type/
