### PR TITLE
pull show doesn't show regular (non-code) comments

### DIFF
--- a/git-hub
+++ b/git-hub
@@ -809,10 +809,7 @@ class IssueUtil (object):
 				**issue)
 
 	@classmethod
-	def print_issue(cls, issue, comments):
-		issue = dict(issue)
-		issue['name'] = cls.name.capitalize()
-		issue['comments'] += issue.get('review_comments', 0)
+	def print_issue_header(cls, issue):
 		issue['labels'] = ' '.join(['['+l['name']+']'
 				for l in issue.get('labels', [])])
 		if issue['labels']:
@@ -827,11 +824,61 @@ class IssueUtil (object):
 
 """,
 				**issue)
-		for comment in comments:
-			body = comment['body']
-			body = '\n'.join(['    '+l for l in body.splitlines()])
-			infof(u'On {created_at}, {user[login]} commented:\n'
-				'{0}\n\n    <{html_url}>\n', body, **comment)
+		if issue['comments'] > 0:
+			infof(u'Comments:')
+
+	@classmethod
+	def print_issue_comment(cls, comment):
+		body = comment['body']
+		body = '\n'.join(['    '+l for l in body.splitlines()])
+		infof(u'On {created_at}, {user[login]} commented:\n'
+			'{0}\n\n    <{html_url}>\n', body, **comment)
+
+	@classmethod
+	def merge_issue_comments(cls, comments, review_comments):
+		for c in comments:
+			c['sort_key'] = c['created_at']
+		prev_commit_pos = None
+		prev_created = None
+		for c in review_comments:
+			curr_commit_pos = c['commit_id'], c['position']
+			if prev_commit_pos is None:
+				prev_commit_pos = curr_commit_pos
+				prev_created = c['created_at']
+			if prev_commit_pos == curr_commit_pos:
+				c['sort_key'] = '%s %s %s' % (prev_created,
+					prev_commit_pos[0], prev_commit_pos[1])
+			else:
+				prev_commit_pos = None
+				prev_created = None
+		comments = comments + review_comments
+		comments.sort(key=lambda c: c['sort_key'])
+		return comments
+
+	@classmethod
+	def print_issue(cls, issue, comments, review_comments=()):
+		issue = dict(issue)
+		issue['name'] = cls.name.capitalize()
+		issue['comments'] += len(comments) + len(review_comments)
+		cls.print_issue_header(issue)
+		prev_commit_pos = None
+		for c in cls.merge_issue_comments(comments, review_comments):
+			if 'diff_hunk' in c:
+				curr_commit_pos = c['commit_id'], ['position']
+				if prev_commit_pos is None:
+					infof(u'{}\n', u'-' * 80)
+					infof(u'diff --git a/{path} b/{path}\n'
+						u'index {original_commit_id}..{commit_id}\n'
+						u'--- a/{path}\n'
+						u'+++ b/{path}\n'
+						u'{diff_hunk}\n',
+						**c)
+					prev_commit_pos = curr_commit_pos
+				if prev_commit_pos == curr_commit_pos:
+					cls.print_issue_comment(c)
+			else:
+				infof(u'{}\n', u'-' * 80)
+				cls.print_issue_comment(c)
 
 	@classmethod
 	def print_comment(cls, comment):
@@ -1188,11 +1235,10 @@ class PullCmd (IssueCmd):
 				c = []
 				if pull['comments'] > 0:
 					c = req.get(issue_url + '/comments')
+				ic = []
 				if pull['review_comments'] > 0:
 					ic = req.get(cls.url(n) + "/comments")
-					c.extend(ic)
-					c.sort(key=lambda i: i['created_at'])
-				cls.print_issue(pull, c)
+				cls.print_issue(pull, c, ic)
 
 	class UpdateCmd (PullUtil, IssueCmd.UpdateCmd):
 		cmd_help = "update an existing pull request"


### PR DESCRIPTION
GitHub have 2 different API calls, one for regular comments (`issues/N/comments`) and one for pull request code comments (`pulls/N/comments`). Right now the `pull show N` command is only showing the `pull/N/comments` and regular comments are omitted.
