### PR TITLE
Install files in /usr in the Debian package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ all: man bash-completion
 
 .PHONY: deb
 deb:
-	$(MAKE) DESTDIR=deb/install install
+	$(MAKE) prefix=/usr DESTDIR=deb/install install
 	deb/build
 
 .PHONY: man


### PR DESCRIPTION
The Makefile `deb` rule is broken and is not setting the `prefix`. This
causes the files to be installed in `/usr/local` instead of `/usr` as
regular Debian packages should do.
