### PR TITLE
issue show #ISSUE broken since v0.7.0

### DIFF
--- a/git-hub
+++ b/git-hub
@@ -857,6 +857,7 @@ class IssueUtil (object):
 
 	@classmethod
 	def print_issue(cls, issue, comments, review_comments=()):
+		review_comments = list(review_comments)
 		issue = dict(issue)
 		issue['name'] = cls.name.capitalize()
 		issue['comments'] += len(comments) + len(review_comments)


### PR DESCRIPTION
According to a `git bisect` run 

```
git hub issue show #ISSUE
```

fails since commit `e8d946f`, a.k.a. tagged release `v0.7.0`.

A sample call performed when on that commit in a local repo with `hub.upstream=sociomantic/git-hub` follows:

```
$ ./git-hub issue show 84

#84: Add colors to console output
================================================================================
Issue is open, was reported by leandro-lucarella-sociomantic and has 0
comment(s).
[difficulty-easy] [type-enhancement]
<https://github.com/sociomantic/git-hub/issues/84>

Color output can help a lot to improve the readability of the output, specially
for long output with a lot of information, like the issue/pull show commands. It
also make errors and warnings more visible.


Traceback (most recent call last):
  File "./git-hub", line 1902, in <module>
    main()
  File "./git-hub", line 1896, in main
    args.run(parser, args)
  File "./git-hub", line 614, in check_config_and_run
    cmd.run(parser, args)
  File "./git-hub", line 982, in run
    cls.print_issue(issue, c)
  File "./git-hub", line 865, in print_issue
    for c in cls.merge_issue_comments(comments, review_comments):
  File "./git-hub", line 854, in merge_issue_comments
    comments = comments + review_comments
TypeError: can only concatenate list (not "tuple") to list
```
