### PR TITLE
Better error message needed for non-global setup

### DIFF
--- a/git-hub
+++ b/git-hub
@@ -666,6 +666,15 @@ class SetupCmd (object):
 		auth = req.post('/authorizations', note=note,
 				scopes=['user', 'repo'])
 		set_config = lambda k, v: git_config(k, value=v, opts=args.opts)
+
+		try:
+			if '--system' not in args.opts and \
+					'--global' not in args.opts:
+				git('rev-parse --git-dir')
+		except GitError as error:
+			errf(error.output)
+			die("Maybe you want to use --global or --system?")
+
 		set_config('username', username)
 		set_config('oauthtoken', auth['token'])
 		if args.baseurl is not None:


### PR DESCRIPTION
Attempting to setup git-hub outside a git repository needs the `--global` option, but the error message does not say so explicitly.

terminal output:

```
$> git hub setup
GitHub username [gautam]: gautam-kotian-sociomantic
GitHub password (will not be stored): 
Error: git config hub.username gautam-kotian-sociomantic failed (return code: 255)
error: could not lock config file .git/config: No such file or directory
$>
```
