### PR TITLE
After a git hub clone, hub.forkremote is not set

### DIFF
--- a/git-hub
+++ b/git-hub
@@ -763,6 +763,7 @@ class CloneCmd (object):
 		if triangular:
 			remote_url = repo[config.urltype]
 			git_config('remote.pushdefault', prefix='', value=remote)
+			git_config('forkremote', value=remote)
 		git_config('upstream', value=upstream)
 		git('remote', 'add', remote, remote_url)
 		infof('Fetching from {} ({})', remote, remote_url)

--- a/man.rst
+++ b/man.rst
@@ -91,8 +91,8 @@ COMMANDS
   \-t, --triangular
     Use Git's *triangular workflow* configuration. This option clones from the
     parent/upstream repository instead of cloning the fork, and adds the fork
-    as a remote repository. Then sets the `remote.pushdefault` Git option to
-    the fork.
+    as a remote repository. Then sets the `remote.pushdefault` Git option and
+    `hub.forkremote` git-hub option to the fork.
 
     The effect of this having the upstream repository used by default
     when you pull but using your fork when you push, which is typically what


### PR DESCRIPTION
```
$ git hub clone -t gitpython-developers/GitPython
$ cd GitPython
$ git config hub.forkremote
```

-> empty output, return code 1

```
$ git hub pull new
Pushing 0.3 to 0.3 in origin
Error: git push --quiet --force origin 0.3:refs/heads/0.3 failed (return code: 128)
ERROR: Permission to gitpython-developers/GitPython.git denied to maxyz.
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```

Setting git config hub.forkremote fork fixes the issue.

Happy hacking,
