### PR TITLE
Ask for the final v3 GitHub API version

### DIFF
--- a/git-hub
+++ b/git-hub
@@ -402,7 +402,7 @@ class RequestManager:
 			req.add_header("Authorization", "bearer " +
 					self.oauthtoken)
 		req.add_header("Content-Type", "application/json")
-		req.add_header("Accept", "application/vnd.github.beta+json")
+		req.add_header("Accept", "application/vnd.github.v3+json")
 		req.add_header("Content-Length", str(len(body) if body else 0))
 		req.get_method = lambda: method.upper()
 		debugf('{}', req.get_full_url())


### PR DESCRIPTION
There are no real difference in the kind of API calls we make, so no
other changes are needed.
