### PR TITLE
Add info about the pull request base/head when doing pull new/attach

### DIFF
--- a/git-hub
+++ b/git-hub
@@ -1289,8 +1289,9 @@ class PullCmd (IssueCmd):
 				"used as the optional body")
 			parser.add_argument('-b', '--base', metavar='BASE',
 				help="branch (or git ref) you want your "
-				"changes pulled into (uses hub.pullbase or "
-				"'master' in hub.upstream by default)")
+				"changes pulled into (uses the tracking "
+				"branch by default, or hub.pullbase if "
+				"there is none, or 'master' as a fallback)")
 			parser.add_argument('-c', '--create-branch',
 				metavar='NAME',
 				help="create a new remote branch with NAME "
@@ -1336,8 +1337,9 @@ class PullCmd (IssueCmd):
 				"after attaching the code to it")
 			parser.add_argument('-b', '--base', metavar='BASE',
 				help="branch (or git ref) you want your "
-				"changes pulled into (uses hub.pullbase or "
-				"'master' in hub.upstream by default)")
+				"changes pulled into (uses the tracking "
+				"branch by default, or hub.pullbase if "
+				"there is none, or 'master' as a fallback)")
 			parser.add_argument('-c', '--create-branch',
 				metavar='NAME',
 				help="create a new remote branch with NAME "


### PR DESCRIPTION
The message contains information about the new pull request or the code
attached to an issue, like what's the branch with the proposed changes,
and what's the destination repository and branch.

Also mention how tracking branch is used in pull new/attach. When adding
the tracking branch as a default pull base the man page was updated but
not the command-line help, which is a bit misleading.
