### PR TITLE
clone: Sometimes the wrong fork can be cloned/fetched

### DIFF
--- a/git-hub
+++ b/git-hub
@@ -779,11 +779,18 @@ class CloneCmd (object):
 	@classmethod
 	def repo_from_upstream(cls, upstream):
 		(owner, proj) = upstream.split('/')[-2:]
+		name_found = False
 		for repo in req.get('/user/repos'):
+			if repo['name'] == proj:
+				name_found = True
 			if (repo['fork'] and
 					repo['parent']['full_name'] == upstream):
 				break
 		else: # Fork not found
+			if name_found:
+				die("No fork were found and the we can't name "
+					"the fork '{}' because the '{}' "
+					"already exists", proj, upstream)
 			infof('Forking {} to {}/{}', upstream,
 				config.username, proj)
 			repo = req.post('/repos/' + upstream + '/forks')


### PR DESCRIPTION
Suppose this situation:
1. fake-parent/repo is _standalone_ repo
2. real-parent/repo is a _standalone_ repo
3. fork/repo is a fork of real-parent/repo

Then `git hub -t clone false-parrent/repo` results in the following `.git/config` (only relevant parts):

``` ini
[hub]
    forkremote = fork
    upstream = real-parent/repo
[remote "origin"]
    url = git@github.com:real-parent/repo.git
[remote "fork"]
    url = git@github.com:fork/repo.git
```

Which is clearly wrong (you ended up cloning a different repository than the one you specified in the command line).

An error saying fork/repo already exists and is not a fork of fake-parent/repo should be printed instead, and nothing should be cloned.

Alternatively, more control over what/how to clone should be added.
