### PR TITLE
pull: Don't error and interrupt the rebase on branch deletion fail

### DIFF
--- a/git-hub
+++ b/git-hub
@@ -1782,8 +1782,11 @@ class RebaseCmd (PullUtil):
 			if args.delete_branch:
 				infof('Removing pull request branch {} in {}',
 						head_ref, head_url)
-				git_push(head_url, ':' + head_ref,
-						force=args.force_push)
+				try:
+					git_push(head_url, ':' + head_ref,
+							force=args.force_push)
+				except GitError as e:
+					warnf('Error removing branch: {}', e)
 			return git('rev-parse HEAD')
 		finally:
 			if not cls.in_conflict and not cls.in_pause:


### PR DESCRIPTION
When using `git hub pull rebase --delete` git-hub will fail with:

```
 ! [remote rejected] master (deletion of the current branch prohibited)
```

I think in this case it should just continue rebasing even if it can't delete the branch (or maybe just special case this if `master` is found).
