### PR TITLE
clean_message() doesn't require space after #

### DIFF
--- a/git-hub
+++ b/git-hub
@@ -515,7 +515,7 @@ message_markdown_help = '''\
 def clean_message(msg):
 	lines = msg.splitlines()
 	# Remove comment lines
-	lines = [l for l in lines if not l.strip().startswith('#')]
+	lines = [l for l in lines if not l.startswith('# ') and l != '#']
 	return '\n'.join(lines)
 
 # For messages expecting a title, split the first line as the title and the


### PR DESCRIPTION
`message_markdown_help` says:
> Lines starting with '# ' (note the space after the hash!) will be ignored, and an empty message aborts the command. The space after the hash is required by comments to avoid accidentally commenting out a line starting with a reference to an issue (#4 for example).

But actually `clean_message()` strips all lines starting with `#`, even when there's no space after it.