### PR TITLE
Fix cloning when a fork with the same name exists

### DIFF
--- a/git-hub
+++ b/git-hub
@@ -836,14 +836,14 @@ class CloneCmd (object):
 					repo['full_name'])
 		else:
 			upstream = proj
-			repo_name = proj.split('/')[1]
-			for repo in req.get('/user/repos'):
-				if repo['name'] == repo_name and repo['fork']:
+			for repo in req.get('/repos/' + proj + '/forks'):
+				if repo['owner']['login'] == config.username:
 					break
 			else: # Fork not found
-				infof('Forking {} to {}/{}', upstream,
-					config.username, repo_name)
+				infof('Forking {} to {}', upstream,
+					config.username)
 				repo = req.post('/repos/' + upstream + '/forks')
+				infof('New fork at {}', repo['html_url'])
 			repo = req.get('/repos/' + repo['full_name'])
 		return (repo, upstream)
 


### PR DESCRIPTION
When cloning a repository `hub clone` but the current user already has
a repository with the same name, that repository is used even when it
not a real fork of the repository passed by argument.

This commit searches through the upstream repository forks instead of
the user's repositories to see if a fork already exists. If it doesn't,
a new fork will be created, with a name chosen by GitHub (it will add
a suffix `-1` at the time of writing this). Unfortunately there seem to
be no way to customize that.

A new message is added to print the actual location of the new fork, in
case the name is different from upstream.