### PR TITLE
clone: it takes ages to clone if a project with thousands of forks needs to be forked

### DIFF
--- a/git-hub
+++ b/git-hub
@@ -838,15 +838,15 @@ class CloneCmd (object):
                     repo['full_name'])
         else:
             upstream = proj
-            for repo in req.get('/repos/' + proj + '/forks'):
-                if repo['owner']['login'] == config.username:
-                    break
-            else: # Fork not found
-                infof('Forking {} to {}', upstream,
-                    config.username)
-                repo = req.post('/repos/' + upstream + '/forks')
-                infof('New fork at {}', repo['html_url'])
-            repo = req.get('/repos/' + repo['full_name'])
+            # Try to fork, if a fork already exists, we'll get the
+            # information for the pre-existing fork
+            # XXX: This is not properly documented in the GitHub
+            #      API docs, but it seems to work as of Sep 2016.
+            #      See https://github.com/sociomantic-tsunami/git-hub/pull/193
+            #      for more details.
+            infof('Checking for existing fork / forking...')
+            repo = req.post('/repos/' + upstream + '/forks')
+            infof('Fork at {}', repo['html_url'])
         return (repo, upstream)
 
     @classmethod


### PR DESCRIPTION
When cloning a repository with many forks, and the repository is not forked by us yet, it takes `git hub clone` ages to finish, as it retrieves the list of **ALL** forks for the project to see if we have forked it.

I'm not sure if there is an easy way to fix this, as far as I know there is no way to do it quickly and reliably using the GitHub API. As far as I know, just trying to create the fork will fork it again under a new name, and retrieving the list of forks of the user instead of the forks of the original repo is also flawed (it was like that before d2a4f409e6f33e6a441f9bad1fed08f51318bdeb), and potentially has the same problem if the user have thousands of repositories.