### PR TITLE
rebase: Don't fail fatally if we can't push to PR

### DIFF
--- a/git-hub
+++ b/git-hub
@@ -1814,8 +1814,11 @@ class RebaseCmd (PullUtil):
             if cls.in_pause:
                 cls.in_pause = False
                 cls.remove_rebasing_file()
-            infof('Updating PR branch {} in {}', head_ref, head_url)
-            git_push(head_url, 'HEAD:' + head_ref, force=True)
+            infof('Trying to Update the PR branch {} in {}', head_ref, head_url)
+            try:
+                git_push(head_url, 'HEAD:' + head_ref, force=True)
+            except GitError as e:
+                warnf('Error pushing branch: {}', e)
             infof('Pushing results to {} in {}',
                     base_ref, base_url)
             git_push(base_url, 'HEAD:' + base_ref,


### PR DESCRIPTION
The update to the PR branch to make sure GitHub detects the merge can fail if the user rebasing the PR doesn't have permissions over the repo from where the PR was created (for example is another user's fork).

Because of this, the failure to push to the PR branch should be non-fatal.