### PR TITLE
clone: Use option terminator after options

### DIFF
--- a/git-hub
+++ b/git-hub
@@ -777,7 +777,7 @@ class CloneCmd (object):
 					"an upstream repo")
 		url = repo['parent'][urltype] if triangular else repo[urltype]
 		infof('Cloning {} to {}', url, dest)
-		git_quiet(1, 'clone', *(args.unknown_args + [url, dest]))
+		git_quiet(1, 'clone', *(args.unknown_args + ['--', url, dest]))
 		if not upstream:
 			# Not a forked repository, nothing else to do
 			return


### PR DESCRIPTION
Without using the option terminator, a malicious server could inject undesired options into the command-line (like `--config=core.gitProxy=perl`) to then use the URL to execute arbitrary
code.

This should partially fix #197 (`git-remote-ext` remains as an attack vector).