### PR TITLE
Revert pushing rebased commits also to the PR branch

### DIFF
--- a/git-hub
+++ b/git-hub
@@ -1827,11 +1827,6 @@ class RebaseCmd (PullUtil):
             if cls.in_pause:
                 cls.in_pause = False
                 cls.remove_rebasing_file()
-            infof('Trying to Update the PR branch {} in {}', head_ref, head_url)
-            try:
-                git_push(head_url, 'HEAD:' + head_ref, force=True)
-            except GitError as e:
-                warnf('Error pushing branch: {}', e)
             infof('Pushing results to {} in {}',
                     base_ref, base_url)
             git_push(base_url, 'HEAD:' + base_ref,


### PR DESCRIPTION
This commit revert both d5c31317561b7468da4962ed3bda7805cca03411 and aac3d985db40a39b457a9e4dbe280c52d4f9d2f1.

This feature is of little use as it only works when the user rebasing the PR can push to the repository where the PR branch lives (which is almost never the case) and can cause problems with integration of statuses and CI, as it seems like builds with old hashes are triggered.

We should start using the GitHub API to rebase soon instead anyway.