### PR TITLE
man: wrong description of implicit `issues list` command

### DIFF
--- a/man.rst
+++ b/man.rst
@@ -131,7 +131,6 @@ COMMANDS
 
 `issue`
   This command is used to manage GitHub issues through a set of subcommands.
-  Is no subcommand is specified, `list` is used.
 
   `list`
     Show a list of open issues.


### PR DESCRIPTION
Coming from the Debian tracker [#840363](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=840363).

> The man page says:
> 
> ```
>       issue  This  command is used to manage GitHub issues through a set of subcommands.
>              Is no subcommand is specified, list is used.
> ```
> 
> This is not true:
> 
> ```
> % git hub issue
> usage: git-hub issue [-h] {close,comment,list,new,show,update} ...
> git-hub issue: error: too few arguments
> ```

There is also an (unreported) typo "Is ( -> If) no subcommand is specified...".
