### PR TITLE
Add mention of related project to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -223,6 +223,9 @@ found, in case they are a better fit for you:
   We might try to merge our code into that project eventually, if there is
   interest.
 
+* `gh <https://github.com/node-gh/gh>`_: A command line tool based on **NodeJS**.
+  It does offer the rebase capabilities we sought after, but the project was 
+  created after this project was started. 
 
 Contact
 =======


### PR DESCRIPTION
Adds the `gh` which is based on NodeJS to the section Similar Projects in README. 