### PR TITLE
Fix Debian #846866 (cloning URLs with a trailing /)

### DIFF
--- a/git-hub
+++ b/git-hub
@@ -847,7 +847,7 @@ class CloneCmd (object):
 			repo = config.username + '/' + repo
 		# Get just the owner/repo form from the full URL
 		url = urlparse.urlsplit(repo)
-		proj = '/'.join(url.path.split(':')[-1:][0].split('/')[-2:])
+		proj = '/'.join(url.path.split(':')[-1:][0].strip('/').split('/')[-2:])
 		return (urltype, proj)
 
 	@classmethod


### PR DESCRIPTION
As reported in https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=846866, clone fails when URLs have a trailing /. This commit just strips any leading or trailing / from the URL path.