### PR TITLE
Attaching a PR to an Issue no longer seems to work

### DIFF
--- a/git-hub
+++ b/git-hub
@@ -1513,7 +1513,7 @@ class PullCmd (IssueCmd):
                     "(to be merged to {}:{})", remote_head,
                     args.issue, config.upstream, base)
             pull = req.post(cls.url(), issue=args.issue, base=base,
-                    head=gh_head)
+                    head=gh_head, maintainer_can_modify=False)
             cls.print_issue_summary(pull)
             if msg:
                 cls.clean_and_post_comment(args.issue, msg)


### PR DESCRIPTION
I'm getting a validation failure from github for those.
```
Error: GitHub error: Validation Failed
Error:               fork_collab Fork collab can't be granted by someone without permission
```
Found a hint that this is related to maintainer_can_edit being true by default.
https://github.com/1egoman/backstroke/issues/46#issuecomment-272597511
And indeed passing `maintainer_can_modify=False` with the post in AttachCmd fixes the issue, not sure if `maintainer_can_modify=True` would work as well.