### PR TITLE
Error checking out a pull request which referenced branch has been deleted

### DIFF
--- a/git-hub
+++ b/git-hub
@@ -1535,6 +1535,10 @@ class PullCmd (IssueCmd):
                 warnf('Checking out a closed pull request '
                     '(closed at {closed_at})!', **pull)
 
+            if pull['head']['repo'] is None:
+                die("Can't checkout pull request {number}, no head repository "
+                    "found (maybe it was deleted?)", **pull)
+
             remote_url = pull['head']['repo'][config.urltype]
             remote_branch = pull['head']['ref']
 


### PR DESCRIPTION
The referenced branch has been deleted from an existent pull request.
Trying `git hub pull rebase --pause 123` gives the right error message
`It seems like the repository referenced by this pull request has been deleted`

However trying `git hub pull checkout 123` throws the error
```
Traceback (most recent call last):
  File "/usr/bin/git-hub", line 2103, in <module>
    main()
  File "/usr/bin/git-hub", line 2097, in main
    args.run(parser, args)
  File "/usr/bin/git-hub", line 647, in check_config_and_run
    cmd.run(parser, args)
  File "/usr/bin/git-hub", line 1502, in run
    remote_url = pull['head']['repo'][config.urltype]
TypeError: 'NoneType' object has no attribute '__getitem__'
```