### PR TITLE
Subshell issue when building in a Python 3 environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 
 prefix ?= /usr/local
 
-export PYTHON := python
+export PYTHON := python2
 
 version ?= $(shell git describe --dirty 2> /dev/null | cut -b2-)
 version := $(if $(version),$(version),devel)
@@ -32,7 +32,7 @@ install: git-hub git-hub.1 ftdetect.vim bash-completion README.rst
 	install -m 755 -D git-hub $(DESTDIR)$(prefix)/bin/git-hub
 	sed -i 's/^VERSION = "git-hub devel"$$/VERSION = "git-hub $(version)"/' \
 			$(DESTDIR)$(prefix)/bin/git-hub
-	sed -i 's|^#!/usr/bin/env python$$|#!/usr/bin/env $(PYTHON)|' \
+	sed -i 's|^#!/usr/bin/env python2$$|#!/usr/bin/env $(PYTHON)|' \
 			$(DESTDIR)$(prefix)/bin/git-hub
 	install -m 644 -D git-hub.1 $(DESTDIR)$(prefix)/share/man/man1/git-hub.1
 	install -m 644 -D ftdetect.vim \

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 
 prefix ?= /usr/local
 
-export PYTHON := python2
+export PYTHON ?= python2
 
 version ?= $(shell git describe --dirty 2> /dev/null | cut -b2-)
 version := $(if $(version),$(version),devel)

--- a/generate-bash-completion
+++ b/generate-bash-completion
@@ -6,7 +6,7 @@ set -e
 # Based on the _git_svn completion function in git distribution's bash
 # completion.
 
-PYTHON=${PYTHON:-python}
+PYTHON=${PYTHON:-python2}
 
 issue_arg_cmds="issue-show issue-update issue-comment issue-close pull-attach"
 pull_arg_cmds="pull-show pull-update pull-comment pull-close"

--- a/git-hub
+++ b/git-hub
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # vim: set fileencoding=utf-8 :
 
 # Git command line interface to GitHub.


### PR DESCRIPTION
This error happens when building when `python` is Python 3:

```
$ make install
sed 's/^:Version: devel$/:Version: 0.11.1-4-g2b1f532-dirty/' man.rst | \
   rst2man --exit-status=1 > git-hub.1 || (rm -f git-hub.1 && false)
./generate-bash-completion git-hub > bash-completion || (rm -f bash-completion && false)                                Traceback (most recent call last):
File "git-hub", line 46, in <module>
import urllib2
ModuleNotFoundError: No module named 'urllib2'
make: *** [Makefile:28: bash-completion] Error 1
```

The `generate-bash-completion` script has `PYTHON=${PYTHON:-python}`. That fixes the issue if I `export PYTHON=python2` and run the script directly, but when `make` runs the script, `PYTHON` is not defined and the above error still occurs.  