### PR TITLE
`prefix` is missing for installing bash_completion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,5 @@
 
 prefix ?= /usr/local
-# fall back to $prefix/etc (like autoconf); see discussion on #222
-#sysconfdir ?= $(prefix)/etc)
 # fall back to /etc, ignoring prefix
 sysconfdir ?= /etc
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,9 @@
 
 prefix ?= /usr/local
+# fall back to $prefix/etc (like autoconf); see discussion on #222
+#sysconfdir ?= $(prefix)/etc)
+# fall back to /etc, ignoring prefix
+sysconfdir ?= /etc
 
 export PYTHON := python
 
@@ -37,7 +41,7 @@ install: git-hub git-hub.1 ftdetect.vim bash-completion README.rst
 	install -m 644 -D git-hub.1 $(DESTDIR)$(prefix)/share/man/man1/git-hub.1
 	install -m 644 -D ftdetect.vim \
 		$(DESTDIR)$(prefix)/share/vim/addons/ftdetect/githubmsg.vim
-	-install -m 644 -D bash-completion $(DESTDIR)/etc/bash_completion.d/git-hub
+	install -m 644 -D bash-completion $(DESTDIR)$(sysconfdir)/bash_completion.d/git-hub
 	install -m 644 -D README.rst $(DESTDIR)$(prefix)/share/doc/git-hub/README.rst
 
 .PHONY: release

--- a/README.rst
+++ b/README.rst
@@ -183,7 +183,8 @@ If you built the Debian_/Ubuntu_ package, you can just install the package
 Otherwise you can type ``make install`` to install the tool, man page, *bash
 completion* and VIM_ *ftdetect* plugin (by default in ``/usr/local``, but you
 can pick a different location by passing the ``prefix`` variable to ``make``
-(for example ``make install prefix=/usr``).
+(for example ``make install prefix=/usr``). To pick a location for the
+completion scripts (by default in ``/etc``), use the ``sysconfdir`` variable.
 
 The installation locations might be too specific for Debian_/Ubuntu_ though.
 Please report any failed installation attempts.


### PR DESCRIPTION
```
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ install: git-hub git-hub.1 ftdetect.vim bash-completion README.rst
        install -m 644 -D git-hub.1 $(DESTDIR)$(prefix)/share/man/man1/git-hub.1
        install -m 644 -D ftdetect.vim \
                $(DESTDIR)$(prefix)/share/vim/addons/ftdetect/githubmsg.vim
-       -install -m 644 -D bash-completion $(DESTDIR)/etc/bash_completion.d/git-hub
+       -install -m 644 -D bash-completion $(DESTDIR)$(prefix)/etc/bash_completion.d/git-hub
        install -m 644 -D README.rst $(DESTDIR)$(prefix)/share/doc/git-hub/README.rst
```