### PR TITLE
Update to beaver/cachalot and remove trusty support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -16,3 +16,7 @@ trim_trailing_whitespace = true
 # reStructuredTex and Markdown files
 [**.{rest,rst,md}]
 indent_size = 2
+
+# Makefiles need to use tab for indentation
+[{Makefile,**.mak}]
+indent_style = tab

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ env:
         # Make sure beaver is in the PATH
         - PATH="$(git config -f .gitmodules submodule.beaver.path)/bin:$PATH"
     matrix:
-        - DIST=trusty
         - DIST=xenial
 
 install: beaver install

--- a/beaver.Dockerfile
+++ b/beaver.Dockerfile
@@ -1,1 +1,1 @@
-FROM sociomantictsunami/base:v2
+FROM sociomantictsunami/base:v3


### PR DESCRIPTION
```
* beaver v0.2.1(570562d)...v0.2.2(480e6f5) (3 commits)
  > gen-dockerfile: Fix docker repository and tag parsing
  > editorconfig: Fix indent for Makefiles
  > Mention wildcard support in README
```