### PR TITLE
Unable to checkout pull request from unknown repository

### DIFF
--- a/git-hub
+++ b/git-hub
@@ -1551,14 +1551,10 @@ class PullCmd (IssueCmd):
                 warnf('Checking out a closed pull request '
                     '(closed at {closed_at})!', **pull)
 
-            if pull['head']['repo'] is None:
-                die("Can't checkout pull request {number}, no head repository "
-                    "found (maybe it was deleted?)", **pull)
+            remote_url = pull['base']['repo'][config.urltype]
+            remote_ref = 'pull/{}/head'.format(pull['number'])
 
-            remote_url = pull['head']['repo'][config.urltype]
-            remote_branch = pull['head']['ref']
-
-            cls.git_fetch(remote_url, remote_branch)
+            cls.git_fetch(remote_url, remote_ref)
             git_quiet(1, 'checkout', 'FETCH_HEAD', *args.args)
 
 # This class is top-level just for convenience, because is too big. Is added to


### PR DESCRIPTION
Trying to checkout a pull request which was created by a user that was but is not longer part of the repositories organisation crashes git-hub. In this case Github will say that the pull requests repo is `unknown repository`

```
$ git hub pull checkout ID
Traceback (most recent call last):
  File "/usr/bin/git-hub", line 2043, in <module>
    main()
  File "/usr/bin/git-hub", line 2037, in main
    args.run(parser, args)
  File "/usr/bin/git-hub", line 621, in check_config_and_run
    cmd.run(parser, args)
  File "/usr/bin/git-hub", line 1464, in run
    remote_url = pull['head']['repo'][config.urltype]
TypeError: 'NoneType' object has no attribute '__getitem__'
```

It still possible to checkout the pull request by `git fetch REMOTE pull/ID/head:BRANCHNAME`
