### PR TITLE
Use env variable for rst2man

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ prefix ?= /usr/local
 sysconfdir ?= /etc
 
 export PYTHON ?= python2
-RST2MAN ?=rst2man
+RST2MAN ?= rst2man
 
 version ?= $(shell git describe --dirty 2> /dev/null | cut -b2-)
 version := $(if $(version),$(version),devel)

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ prefix ?= /usr/local
 sysconfdir ?= /etc
 
 export PYTHON ?= python2
+RST2MAN ?=rst2man
 
 version ?= $(shell git describe --dirty 2> /dev/null | cut -b2-)
 version := $(if $(version),$(version),devel)
@@ -26,7 +27,7 @@ man: git-hub.1
 
 git-hub.1: man.rst git-hub
 	sed 's/^:Version: devel$$/:Version: $(version)/' $< | \
-		rst2man --exit-status=1 > $@ || ($(RM) $@ && false)
+		$(RST2MAN) --exit-status=1 > $@ || ($(RM) $@ && false)
 
 bash-completion: generate-bash-completion git-hub
 	./$^ > $@ || ($(RM) $@ && false)

--- a/README.rst
+++ b/README.rst
@@ -186,6 +186,9 @@ can pick a different location by passing the ``prefix`` variable to ``make``
 (for example ``make install prefix=/usr``). To pick a location for the
 completion scripts (by default in ``/etc``), use the ``sysconfdir`` variable.
 
+If Docutils_ is installed using ``pip`` the environment variable ``RST2MAN``
+should be set to ``rst2man.py``.
+
 The installation locations might be too specific for Debian_/Ubuntu_ though.
 Please report any failed installation attempts.
 

--- a/beaver.Dockerfile
+++ b/beaver.Dockerfile
@@ -1,1 +1,1 @@
-FROM sociomantictsunami/base:v6-test
+FROM sociomantictsunami/develbase:v6

--- a/deb/build
+++ b/deb/build
@@ -32,7 +32,7 @@ fpm -s dir -t deb -n "$pkgname" -v "$pkgversion" \
 	--maintainer "$pkgmaint" \
 	--description "Git command line interface to GitHub" \
 	--url 'https://github.com/sociomantic-tsunami/git-hub' \
-	--vendor 'Sociomantic Labs GmbH' \
+	--vendor 'dunnhumby Germany GmbH' \
 	--license GPLv3 \
 	--category vcs \
 	--depends python2.7 \

--- a/git-hub
+++ b/git-hub
@@ -3,9 +3,10 @@
 
 # Git command line interface to GitHub.
 #
-# Written by Leandro Lucarella <leandro.lucarella@sociomantic.com>
+# Written by Leandro Lucarella <leandro.lucarella@dunnhumby.com>
 #
-# Copyright (c) 2013 by Sociomantic Labs GmbH
+# Copyright (c) 2013 dunnhumby Germany GmbH.
+# All rights reserved.
 #
 # This program is written as a single file for practical reasons, this way
 # users can download just one file and use it, while if it's spread across

--- a/git-hub
+++ b/git-hub
@@ -950,15 +950,15 @@ class CloneCmd (object):
             warnf("Current git version ({}) has an issue when "
                 "using the option push.default=simple and "
                 "using the --triangular workflow. Please "
-                "use Git {} or newer, or change push.default "
+                "use git {} or newer, or change push.default "
                 "to 'current' for example. Ignoring the "
                 "--triangular option...", cur_ver, min_ver)
             return False
         return True
 
 
-# Utility class that group common functionality used by the multiple `git hub
-# issue` (and `git hub pull`) subcommands.
+# Utility class that groups common functionality used by the multiple 
+# `git hub issue` (and `git hub pull`) subcommands.
 class IssueUtil (object):
 
     cmd_required_config = ['upstream', 'oauthtoken']
@@ -972,7 +972,7 @@ class IssueUtil (object):
 # Please enter the title and description below.
 #
 # The first line is interpreted as the title. An optional description
-# can follow after and empty line.
+# can follow after an empty line.
 #
 # Example:
 #
@@ -1309,8 +1309,8 @@ class IssueCmd (CmdGroup):
             cls.print_issue_summary(issue)
 
 
-# Utility class that group common functionality used by the multiple `git hub
-# pull`) subcommands specifically.
+# Utility class that groups common functionality used by the multiple 
+# `git hub pull`) subcommands specifically.
 class PullUtil (IssueUtil):
 
     name = 'pull request'

--- a/man.rst
+++ b/man.rst
@@ -6,8 +6,8 @@ git-hub
 Git command line interface to GitHub
 ------------------------------------
 
-:Author: Leandro Lucarella <leandro.lucarella@sociomantic.com>
-:Copyright: 2013 Sociomantic Labs GmbH
+:Author: Leandro Lucarella <leandro.lucarella@dunnhumby.com>
+:Copyright: 2013 dunnhumby Germany GmbH
 :Version: devel
 :Date: |date|
 :Manual section: 1


### PR DESCRIPTION
Allow the user to specify the `rst2man` executable using an environment variable.

Fixes an issue where the **make** target `git-hub.1` fails when `docutils` is installed using `pip`.
The reason is that `pip` installs `rst2man` as `rst2man.py`.