### PR TITLE
Support issue and pull request templates

### DIFF
--- a/git-hub
+++ b/git-hub
@@ -308,6 +308,9 @@ def git_config(name, default=None, prefix=GIT_CONFIG_PREFIX, value=None, opts=()
 def git_dir():
     return git('rev-parse', '--git-dir')
 
+# Returns the absolute path of the top-level directory
+def git_toplevel_dir():
+    return git('rev-parse', '--show-toplevel')
 
 # Invokes the editor defined by git var GIT_EDITOR.
 #
@@ -1112,6 +1115,35 @@ class IssueUtil (object):
         comment = req.post(url, body=body)
         cls.print_comment(comment)
 
+    # Add the first template file content found to the message. If the message
+    # already exists, the template content is added between the title and the
+    # body of the existent message.
+    @classmethod
+    def add_template(cls, msg, template_names):
+        if not template_names:
+            return msg
+
+        directories = (git_toplevel_dir(),
+            os.path.join(git_toplevel_dir(), '.github'), git_dir())
+
+        template = None
+        for d, f in ((d, f) for d in directories for f in template_names):
+            path = os.path.join(d, f)
+            if os.path.exists(path):
+                try:
+                    file = open(path, "r")
+                    template = file.read()
+                    break
+                except EnvironmentError as e:
+                    die("Error reading template from path '{}': {}", path, e)
+        if template:
+            if msg:
+                (title, body) = split_titled_message(msg)
+                msg = title + "\n\n" + template + "\n" + body
+            else:
+                msg = template
+        return msg
+
 # `git hub issue` command implementation
 class IssueCmd (CmdGroup):
 
@@ -1199,9 +1231,17 @@ class IssueCmd (CmdGroup):
             parser.add_argument('-M', '--milestone', metavar='ID', type=int,
                     help="assign the milestone identified by the "
                     "number ID to the %s" % cls.name)
+            parser.add_argument('--no-template',
+                    action='store_true', default=False,
+                    help="Do not add the template content to the message")
         @classmethod
         def run(cls, parser, args):
-            msg = args.message or cls.editor()
+            msg = args.message
+            if not args.no_template:
+                templates = ('ISSUE_TEMPLATE', 'ISSUE_TEMPLATE.md')
+                msg = cls.add_template(msg, templates)
+            if not args.message:
+                msg = cls.editor(msg)
             (title, body) = split_titled_message(msg)
             issue = req.post(cls.url(), title=title, body=body,
                     assignee=args.assignee, labels=args.labels,
@@ -1501,8 +1541,13 @@ class PullCmd (IssueCmd):
                     cls.get_local_remote_heads(parser, args)
             msg = args.message
             if not msg:
-                msg = cls.editor(cls.get_default_branch_msg(
-                        head_ref, head_name))
+                msg = cls.get_default_branch_msg(head_ref, head_name)
+            if not args.no_template:
+                template_names = ('PULL_REQUEST_TEMPLATE',
+                        'PULL_REQUEST_TEMPLATE.md')
+                msg = cls.add_template(msg, template_names)
+            if not args.message:
+                msg = cls.editor(msg)
             (title, body) = split_titled_message(msg)
             cls.push(head_name or head_ref, remote_head,
                     force=args.force_push)

--- a/man.rst
+++ b/man.rst
@@ -171,6 +171,14 @@ COMMANDS
   `new`
     Create a new issue.
 
+    The content of the template files **ISSUE_TEMPLATE** or
+    **ISSUE_TEMPLATE.md** will be added to the issue message if any of those
+    template files is found in the top-level directory of the project, the
+    **.github** directory or the **.git** directory.
+    The order for template files lookups matters and it follows the order
+    as described above for template file names and directories. And only the
+    content of the first template found will be added.
+
     \-m MSG, --message=MSG
       Issue title (and description). The first line is used as the issue title
       and any text after an empty line is used as the optional body.  If this
@@ -185,6 +193,9 @@ COMMANDS
 
     \-M ID, --milestone=ID
       Assign the milestone identified by the number ID to the issue.
+
+    \--no-template
+      Do not add the template content to the message.
 
   `update` ISSUE
     Similar to `new` but update an existing issue identified by **ISSUE**.
@@ -274,6 +285,14 @@ COMMANDS
     The repository to issue the pull request from is taken from the
     `hub.forkrepo` configuration, which defaults to
     *hub.username/<hub.upstream project part>*.
+
+    The content of the template files **PULL_REQUEST_TEMPLATE** or
+    **PULL_REQUEST_TEMPLATE.md** will be added to the pull request message
+    if any of those template files is found in the top-level directory of
+    the project, the **.github** directory or the **.git** directory.
+    The order for template files lookups matters and it follows the order
+    as described above for template file names and directories. And only the
+    content of the first template found will be added.
 
     \-m MSG, --message=MSG
       Pull request title (and description). The first line is used as the pull

--- a/relnotes/templates.feature.md
+++ b/relnotes/templates.feature.md
@@ -1,0 +1,24 @@
+### Support issue and pull request templates
+
+* The commands `git-hub issue new` and `git-hub pull new` add template
+contents to the issue or pull request message respectively.
+
+Looks for a template file in the root directory of the project,
+the `.github` directory and the `.git` directory until the first
+template file is found. Then reads the content from the template
+file found and adds it to the message of the issue or pull request.
+
+The supported file names for issue templates are `ISSUE_TEMPLATE`
+and `ISSUE_TEMPLATE.md`, and for pull request templates are
+`PULL_REQUEST_TEMPLATE` and `PULL_REQUEST_TEMPLATE.md`.
+The order for template lookups matters meaning that a template
+file name without extension is looked up first followed by the
+template file name with extension `.md`.
+
+Note that only the content of the first issue or pull request
+template found is added to the message of the issue or pull request
+respectively.
+
+Finally the commands `git-hub issue new` and `git-hub pull new`
+also accept `--no-template` to skip adding the template content
+to the issue or pull request message respectively.


### PR DESCRIPTION
The commands `git-hub issue new` and `git-hub pull new` add template            
contents to the issue or pull request body respectively.                        
                                                                                
Looks for a template file in the root directory of the project,                 
the `.github` directory and the `.git` directory until the first                
template file is found. Then reads the content from the template                
file found and adds it to the body of the issue or pull request.                
                                                                                
The supported file names for issue templates are `ISSUE_TEMPLATE`               
and `ISSUE_TEMPLATE.md`, and for pull request templates are                     
`PULL_REQUEST_TEMPLATE` and `PULL_REQUEST_TEMPLATE.md`.                         
The order for template lookups matters meaning that a template                  
file name without extension is looked up first followed by the                  
template file name with extension `.md`.                                        
                                                                                
Note that only the content of the first issue or pull request                   
template found is added to the body of the issue or pull request                
respectively.                                                                   
                                                                                
Finally the commands `git-hub issue new` and `git-hub pull new`                 
also accept `--no-template` to skip adding template contents to                 
the issue or pull request body respectively.

Addresses #273