### PR TITLE
Fix unicode in PR title or description

### DIFF
--- a/git-hub
+++ b/git-hub
@@ -50,6 +50,7 @@ import os.path
 import urlparse
 import argparse
 import subprocess
+import io
 
 # Output levels according to user selected verbosity
 DEBUG = 3
@@ -322,13 +323,12 @@ def git_dir():
 def editor(help_msg, msg=None):
     prog = git('var', 'GIT_EDITOR')
     fname = os.path.join(git_dir(), 'HUB_EDITMSG')
-    with open(fname, 'w') as f:
-        f.write(msg or '')
-        f.write(help_msg)
+    with io.open(fname, 'w') as f:
+        f.write(u''.join([msg or '', help_msg]))
     status = subprocess.call([prog + ' "$@"', prog, fname], shell=True)
     if status != 0:
         die("Editor returned {}, aborting...", status)
-    with open(fname) as f:
+    with io.open(fname) as f:
         msg = f.read()
     return msg
 


### PR DESCRIPTION
PR title or description containing characters like áéíóúæç throws a UnicodeEncodeError.

Python 2 default encoding is the ASCII encoding and raises a UnicodeEncodeError exception converting a Unicode string into the ASCII encoding if a code point (byte value) is greater than 127. 
The built-in open() is not consistent from Python 2 to 3. In Python 2 open() uses the ASCII encoding for opening a file in text mode to read/write contents while in Python 3 is platform-dependent encoding (whatever locale.getpreferredencoding() returns) or a specific encoding can be given as a parameter.

Using io.open() instead of the built-in open() will handle correctly ASCII and Unicode strings when opening file to read/write contents and also ensures consistency from Python 2 to 3 (actually io.open() is the built-in open() in Python 3).

Fix #276