### PR TITLE
Add option to retrieve oauthtoken from a password store (take 2)

### DIFF
--- a/git-hub
+++ b/git-hub
@@ -343,14 +343,13 @@ class Config:
     def __init__(self):
         self.username = git_config('username', getpass.getuser())
         self.oauthtoken = git_config('oauthtoken')
-        self.oauthtokencmd = git_config('oauthtokencmd')
-        if self.oauthtokencmd is not None:
+        if self.oauthtoken is not None and self.oauthtoken.startswith('!'):
             try:
-                self.oauthtoken = subprocess.check_output(
-                        self.oauthtokencmd, shell=True).strip()
+                cmd = self.oauthtoken[1:]
+                self.oauthtoken = subprocess.check_output(cmd,
+                        shell=True).strip()
             except (OSError, subprocess.CalledProcessError) as e:
-                die("Failed to run oauthtokencmd `{}`: {}",
-                    self.oauthtokencmd, e)
+                die("Failed to run oauthtoken command `{}`: {}", cmd, e)
         self.upstream = git_config('upstream')
         if self.upstream and '/' not in self.upstream:
             die("Invalid hub.upstream configuration, '/' not found")

--- a/git-hub
+++ b/git-hub
@@ -347,7 +347,7 @@ class Config:
             try:
                 cmd = self.oauthtoken[1:]
                 self.oauthtoken = subprocess.check_output(cmd,
-                        shell=True).strip()
+                        shell=True).decode().strip()
             except (OSError, subprocess.CalledProcessError) as e:
                 die("Failed to run oauthtoken command `{}`: {}", cmd, e)
         self.upstream = git_config('upstream')

--- a/git-hub
+++ b/git-hub
@@ -343,6 +343,14 @@ class Config:
     def __init__(self):
         self.username = git_config('username', getpass.getuser())
         self.oauthtoken = git_config('oauthtoken')
+        self.oauthtokencmd = git_config('oauthtokencmd')
+        if self.oauthtokencmd is not None:
+            try:
+                self.oauthtoken = subprocess.check_output(
+                        self.oauthtokencmd, shell=True).strip()
+            except (OSError, subprocess.CalledProcessError) as e:
+                die("Failed to run oauthtokencmd `{}`: {}",
+                    self.oauthtokencmd, e)
         self.upstream = git_config('upstream')
         if self.upstream and '/' not in self.upstream:
             die("Invalid hub.upstream configuration, '/' not found")

--- a/man.rst
+++ b/man.rst
@@ -479,6 +479,10 @@ from. These are the git config keys used:
   required, you shouldn't need to set this variable manually. Use the `setup`
   command instead.
 
+`hub.oauthtokencmd`
+  A command to retrieve the oauth token from a password store.
+  When set, `hub.oauthtoken` isn't needed.
+
 `hub.upstream` required
   Blessed repository used to get the issues from and make the pull requests to.
   The format is *<owner>/<project>*. This option can be automatically set by

--- a/man.rst
+++ b/man.rst
@@ -479,9 +479,11 @@ from. These are the git config keys used:
   required, you shouldn't need to set this variable manually. Use the `setup`
   command instead.
 
-`hub.oauthtokencmd`
-  A command to retrieve the oauth token from a password store.
-  When set, `hub.oauthtoken` isn't needed.
+  If you don't want to store the token in plain text, you can also specify
+  a command by prefixing a `!`. The output of that command will be used as the
+  token. The command will be run with the default shell.
+
+  For example: `oauthtoken = !password-manager ~/my.db get github-oauth-token`.
 
 `hub.upstream` required
   Blessed repository used to get the issues from and make the pull requests to.

--- a/relnotes/oauthtoken-command.feature.md
+++ b/relnotes/oauthtoken-command.feature.md
@@ -1,0 +1,12 @@
+### Allow specifying a command to get the `oauthtoken`
+
+Sometimes storing OAuth token in plain text is not a great idea, so now the
+`oauthtoken` configuration variable can use a shell command to get the token
+instead. Just prepend a `!` and write the command you want to run instead of
+using the token.
+
+For example:
+
+```sh
+git config hub.oauthtoken '!password-manager ~/my.db get github-oauth-token'
+```


### PR DESCRIPTION
This PR is an improvement over @eonpatapon's https://github.com/sociomantic-tsunami/git-hub/pull/277 (thanks!).

It re-uses `oauthtoken` instead of adding a new config option. If it starts with a `!` then it is interpreted as a command to run get the token instead of the plain text token.