### PR TITLE
pull new: Error if no base branch can be inferred reliably

### DIFF
--- a/git-hub
+++ b/git-hub
@@ -359,7 +359,6 @@ class Config:
             self.forkrepo = self.username + '/' + upstream[1]
         self.upstreamremote = git_config('upstreamremote', 'upstream')
         self.forkremote = git_config('forkremote', 'fork')
-        self.pullbase = git_config('pullbase', 'master')
         self.urltype = git_config('urltype', 'ssh_url')
         self.baseurl = self.sanitize_url('baseurl',
             git_config('baseurl', 'https://api.github.com'))
@@ -1423,7 +1422,13 @@ class PullUtil (IssueUtil):
             die("Can't guess remote branch name, please "
                 "use --create-branch to specify one")
         base = args.base or cls.tracking_branch(head_name) or \
-                config.pullbase
+                git_config('pullbase')
+        if base is None:
+            die('No base branch specified, you have to either use --base, have '
+                    'a tracking branch configured for the current branch or '
+                    'configure a default using `git config hub.pullbase` (to '
+                    're-enable the old global `master` default, use `git '
+                    'config --global hub.pullbase master`)')
         gh_head = config.forkrepo.split('/')[0] + ':' + remote_head
         return head_ref, head_name, remote_head, base, gh_head
 
@@ -1495,7 +1500,7 @@ class PullCmd (IssueCmd):
                     help="branch (or git ref) you want your "
                     "changes pulled into (uses the tracking "
                     "branch by default, or hub.pullbase if "
-                    "there is none, or 'master' as a fallback)")
+                    "there is none)")
             parser.add_argument('-c', '--create-branch',
                     metavar='NAME',
                     help="create a new remote branch with NAME "

--- a/man.rst
+++ b/man.rst
@@ -330,8 +330,7 @@ __ https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-gith
       Branch (or git ref) you want your changes pulled into. By default the
       tracking branch (`branch.<ref>.merge` configuration variable) is used or
       the configuration `hub.pullbase` if not tracking a remote branch. If none
-      is present, it defaults to **master**. The repository to use as the base
-      is taken from the `hub.upstream` configuration.
+      is present an error will be displayed.
 
     \-c NAME, --create-branch=NAME
       Create a new remote branch with (with name **NAME**) as the real head for
@@ -367,11 +366,7 @@ __ https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-gith
       first commit message is used as with the `new` subcommand.
 
     \-b BASE, --base=BASE
-      Base branch to which issue the pull request. If this option is not
-      present, then the base branch is taken from the configuration
-      `hub.pullbase` (or just **master** if that configuration is not present
-      either). The repository to use as the base is taken from the
-      `hub.upstream` configuration.
+      Same as `pull new`, please see the details there.
 
     \-c NAME, --create-branch=NAME
       Create a new remote branch with (with name **NAME**) as the real head for

--- a/relnotes/master-base-default.migration.md
+++ b/relnotes/master-base-default.migration.md
@@ -1,0 +1,12 @@
+### No last resort default for `pull new`/`attach --base`
+
+The old `master` default made little sense, as repositories sometimes have
+a different default branch, or have no `master` at all. Now that GitHub have
+changed the default branch to `main` for new projects (and many projects are
+moving away from using `master` as a name for anything altogether) it makes
+less sense that ever to use this last resort default.
+
+An error will be shown if the `pull new` or `pull attach` commands have no
+remote tracking branch or a `hub.pullbase` configuration is present. If you
+relied on this behaviour just do: `git config hub.pullbase master` (add
+`--global` to set this default globally for all your repos).


### PR DESCRIPTION
If there's no tracking branch configured and no `hub.pullbase` set, the default base branch for `pull new` is `master`. This is good default most of the time. However, if there is no local branch named `master`, this is almost certainly wrong choice. I'd like git-hub to require user to explicitly use `-b`/`--base` in such case.

**Note:** This comment was written by @jwilk, GitHub will change the issue author when is converted to a PR by attaching code :unamused: