### PR TITLE
Update setup command to use a pre-existing PAT

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,10 +45,29 @@ __ https://github.com/sociomantic-tsunami/git-hub/blob/master/man.rst
 
 One time global setup to get the credentials
 --------------------------------------------
+
+To use this tool you most likely will need a GitHub PAT (personal access token).
+If you don't have one you regularly use, you can `create a new one`__ (check
+`GitHub docs`__ if you need more help).
+
+Make sure your PAT has at least **repo** and **user** scope.
+
+Then you can use ``git hub setup`` to save it.
+
+__ https://github.com/settings/tokens/new
+__ https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token
+
 ::
 
   $ git hub setup --global --user octocat
-  GitHub password (will not be stored):
+
+  You need to use a GitHub Personal Access Token to do almost anything useful.
+  To create one you can go to: https://github.com/settings/tokens/new.
+  More help at: https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token.
+
+  GitHub token: ******
+  Saved git config hub.username
+  Saved git config hub.oauthtoken
 
 You can revoke this credentials at any time in the `GitHub Applications Settings
 page`__.

--- a/git-hub
+++ b/git-hub
@@ -409,38 +409,24 @@ class Config:
 #
 #    r = req.post('/repos/sociomantic-tsunami/test/labels/', name=name, color=color)
 #
-# The basic auth has priority over oauthtoken for authentication. If you want
-# to use OAuth just leave `basic_auth` and set `oauthtoken`. To fill the
-# `basic_auth` member, the `set_basic_auth()` convenient method is provided).
-#
-# See https://developer.github.com/ for more details on the GitHub API
+# See https://docs.github.com/en/free-pro-team@latest/rest for more details on
+# the GitHub API
 class RequestManager:
 
-    basic_auth = None
     oauthtoken = None
     links_re = re.compile(r'<([^>]+)>;.*rel=[\'"]?([^"]+)[\'"]?', re.M)
 
-    def __init__(self, base_url, oauthtoken=None,
-            username=None, password=None):
+    def __init__(self, base_url, oauthtoken=None):
         self.base_url = base_url
         if oauthtoken is not None:
             self.oauthtoken = oauthtoken
-        elif username is not None:
-            self.set_basic_auth(username, password)
-
-    # Configure the class to use basic authentication instead of OAuth
-    def set_basic_auth(self, username, password):
-        self.basic_auth = b"Basic " + base64.urlsafe_b64encode(
-                _encode("%s:%s" % (username, password)))
 
     # Open an URL in an authenticated manner using the specified HTTP
     # method. It also add other convenience headers, like Content-Type,
     # Accept (both to json) and Content-Length).
     def auth_urlopen(self, url, method, data, media_type):
         req = urllib.request.Request(url, _encode(data))
-        if self.basic_auth:
-            req.add_header("Authorization", self.basic_auth)
-        elif self.oauthtoken:
+        if self.oauthtoken:
             req.add_header("Authorization", "token " + self.oauthtoken)
         req.add_header("Content-Type", "application/json")
         req.add_header("Accept", media_type)
@@ -695,8 +681,8 @@ class SetupCmd (object):
                 "will be searched and used instead, if found (for "
                 "this to work the e-mail must be part of the public "
                 "profile)")
-        parser.add_argument('-p', '--password',
-                help="GitHub's password (will not be stored)")
+        parser.add_argument('-o', '--oauthtoken', metavar='TOKEN',
+                help="GitHub Personal Access Token (PAT) to use")
         parser.add_argument('-b', '--baseurl', metavar='URL',
                 help="GitHub's base URL to use to access the API "
                 "(Enterprise servers usually use https://host/api/v3)")
@@ -726,62 +712,41 @@ class SetupCmd (object):
             infof("Using Git repository local configuration")
 
         username = args.username
-        password = args.password
-        if (username is None or password is None) and \
-                not sys.stdin.isatty():
-            die("Can't perform an interactive setup outside a tty")
         if username is None:
-            username = config.username or getpass.getuser()
+            username = config.username
             reply = user_input('GitHub username [%s]: ' % username)
             if reply:
                 username = reply
-        if password is None:
+
+        oauthtoken = args.oauthtoken
+        if oauthtoken is None:
+            infof("\nYou need to use a GitHub Personal Access Token to do "
+                "almost anything useful. To create one you can go to: "
+                "https://github.com/settings/tokens/new.\nMore help at: "
+                "https://docs.github.com/en/free-pro-team@latest/github/"
+                "authenticating-to-github/creating-a-personal-access-token.\n")
             try:
-                password = getpass.getpass('GitHub '
-                        'password (will not be stored): ')
-            except EOFError:
+                oauthtoken = getpass.getpass('GitHub token: ')
+            except EOFError as e:
                 sys.stdout.write('\n')
-                password = ''
+                warnf("Couldn't read Personal Access Token: {}", e)
+        if oauthtoken == "":
+            oauthtoken = None
+            warnf("Token will not be used because it's empty.")
+
         if '@' in username:
             infof("E-mail used to authenticate, trying to "
                     "retrieve the GitHub username...")
             username = cls.find_username(username)
             infof("Found: {}", username)
 
-        req.set_basic_auth(username, password)
-
-        note = 'git-hub'
-        if not is_global and config.forkrepo:
-            proj = config.forkrepo.split('/', 1)[1]
-            note += ' (%s)' % proj
-
-        while True:
-            infof("Looking for GitHub authorization token...")
-            auths = dict(
-                    [(a['note'], a) for a in req.get('/authorizations')])
-
-            if note not in auths:
-                break
-
-            errf("The OAuth token with name '{}' already exists.", note)
-            infof("If you want to create a new one, enter a "
-                    "name for it. Otherwise you can go to "
-                    "https://github.com/settings/tokens to "
-                    "regenerate or delete the token '{}'", note)
-            note = user_input("Enter a new token name (an empty "
-                    "name cancels the setup): ")
-
-            if not note:
-                sys.exit(0)
-
-        infof("Creating auth token '{}'", note)
-        auth = req.post('/authorizations', note=note,
-                scopes=['user', 'repo'])
-
-        set_config = lambda k, v: git_config(k, value=v, opts=args.opts)
+        def set_config(k, v):
+            git_config(k, value=v, opts=args.opts)
+            infof("Saved git config {}{}", GIT_CONFIG_PREFIX, k)
 
         set_config('username', username)
-        set_config('oauthtoken', auth['token'])
+        if oauthtoken is not None:
+            set_config('oauthtoken', oauthtoken)
         if args.baseurl is not None:
             set_config('baseurl', args.baseurl)
 

--- a/git-hub
+++ b/git-hub
@@ -441,7 +441,7 @@ class RequestManager:
         if self.basic_auth:
             req.add_header("Authorization", self.basic_auth)
         elif self.oauthtoken:
-            req.add_header("Authorization", "bearer " + self.oauthtoken)
+            req.add_header("Authorization", "token " + self.oauthtoken)
         req.add_header("Content-Type", "application/json")
         req.add_header("Accept", media_type)
         req.add_header("Content-Length", str(len(data) if data else 0))

--- a/man.rst
+++ b/man.rst
@@ -55,15 +55,21 @@ COMMANDS
 
 `setup`
   This command performs an initial setup to connect to GitHub. It basically
-  asks GitHub for an authorization token and stores it in the Git configuration
-  variable `hub.oauthtoken` for future use so you don't need to type your
-  password each time (or store it in the config). The username is also stored
-  for future use in the `hub.username` variable. If the base URL is specified,
-  it is stored in `hub.baseurl` too. By default configuration is stored in the
-  repository's ``.git/config`` file (using ``git config``). If you want your
-  configuration to be global to your user or system-wide, use the ``--global``
-  or ``--system`` option respectively. These options are passed straight to
-  ``git config``.
+  asks for a username and a GitHub Personal Access Token (PAT), which is
+  needed to perform most actions.
+
+  The token will be stored it in the Git configuration variable
+  `hub.oauthtoken` for future use. If you don't have one, you can `create it`__
+  (check `GitHub docs`__ if you need more help).  Make sure your PAT has at
+  least **repo** and **user** scope.
+
+  The username is also stored for future use in the `hub.username` variable. If
+  the base URL is specified, it is stored in `hub.baseurl` too.
+
+  By default configuration is stored in the repository's ``.git/config`` file
+  (using ``git config``). If you want your configuration to be global to your
+  user or system-wide, use the ``--global`` or ``--system`` option
+  respectively. These options are passed straight to ``git config``.
 
   \-u USERNAME, --username=USERNAME
     GitHub's username (login name), will be stored in the configuration
@@ -71,8 +77,11 @@ COMMANDS
     that e-mail will be searched and used instead, if found (for this to work
     the e-mail must be part of the public profile).
 
-  \-p PASSWORD, --password=PASSWORD
-    GitHub's password (will not be stored).
+  \-o TOKEN, --oauthtoken=TOKEN
+    GitHub's Personal Access Token (PAT), will be stored in the configuration
+    variable `hub.username`. If an e-mail is provided, then a username matching
+    that e-mail will be searched and used instead, if found (for this to work
+    the e-mail must be part of the public profile).
 
   \-b URL, --baseurl=URL
     GitHub's base URL to use to access the API. Set this when your GitHub API is
@@ -86,6 +95,9 @@ COMMANDS
   \--system
     Store settings in the system configuration (see --system option in `git
     config(1)` for details).
+
+__ https://github.com/settings/tokens/new
+__ https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token
 
 `clone` REPO [DEST]
   This command is used to clone **REPO**, a GitHub repository, to a **DEST**


### PR DESCRIPTION
GitHub doesn't support other means of authentication other than PAT
(Personal Access Token) for a while now, so there is no way to create a
PAT ourselves by using basic auth as in the past.

This completely broke the setup command, which now fails
unconditionally, creating a very very bad entry point to the tool (and
probably leaving most users believing the tool is completely broken).

This commit removes basic authentication completely and adds a way to specify
a PAT explicitly via the setup command. It also adds some help on how to create
the PAT.

Fixes #288 (and it is somehow related to #107).