### PR TITLE
Remove special media type for pull request drafts

### DIFF
--- a/git-hub
+++ b/git-hub
@@ -1556,14 +1556,8 @@ class PullCmd (IssueCmd):
                     force=args.force_push)
             infof("Creating pull request from branch {} to {}:{}",
                     remote_head, config.upstream, base)
-            if args.draft:
-                # The draft feature is only available in a custom media type
-                media_type = "application/vnd.github.shadow-cat-preview+json"
-                pull = req.post(cls.url(), media_type, head=gh_head, base=base,
-                        title=title, body=body, draft=args.draft)
-            else:
-                pull = req.post(cls.url(), head=gh_head, base=base,
-                        title=title, body=body)
+            pull = req.post(cls.url(), head=gh_head, base=base, title=title,
+                    body=body, draft=args.draft)
             IssueCmd.UpdateCmd._do_update(pull['number'], args.labels,
                     args.assignee, args.milestone)
             cls.print_issue_summary(pull)


### PR DESCRIPTION
The Shadow-cat API changes graduated and the custom media type is not
longer needed.

https://developer.github.com/changes/2020-04-07-graduated-previews/

/cc @zullix @daniel-zullo-sociomantic (as you implemented the original feature)