### PR TITLE
pull: Verify the existence of the base branch

### DIFF
--- a/git-hub
+++ b/git-hub
@@ -1464,6 +1464,19 @@ class PullUtil (IssueUtil):
         infof('Fetching {} from {}', ref, url)
         git_quiet(1, 'fetch', '--', url, ref)
 
+    # Checks if the base branch exists (and die if it doesn't)
+    @staticmethod
+    def ensure_github_branch_exists(base):
+        try:
+            req.get('/repos/{}/branches/{}'.format(config.upstream, base))
+        except urllib.error.HTTPError as error:
+            if error.code == 404:
+                die("The base branch '{}' or upstream repo '{}' don't "
+                        "exist (or you don't have enough permissions). "
+                        "Please speficy a valid base branch using `--base` "
+                        "and upstream repo using `git config hub.upstream "
+                        "<owner>/<repo>`.", base, config.upstream)
+
 # `git hub pull` command implementation
 class PullCmd (IssueCmd):
 
@@ -1556,6 +1569,7 @@ class PullCmd (IssueCmd):
                     force=args.force_push)
             infof("Creating pull request from branch {} to {}:{}",
                     remote_head, config.upstream, base)
+            cls.ensure_github_branch_exists(base)
             pull = req.post(cls.url(), head=gh_head, base=base, title=title,
                     body=body, draft=args.draft)
             IssueCmd.UpdateCmd._do_update(pull['number'], args.labels,
@@ -1608,6 +1622,7 @@ class PullCmd (IssueCmd):
             infof("Attaching commits in branch {} to issue #{} "
                     "(to be merged to {}:{})", remote_head,
                     args.issue, config.upstream, base)
+            cls.ensure_github_branch_exists(base)
             pull = req.post(cls.url(), issue=args.issue, base=base,
                     head=gh_head, maintainer_can_modify=False)
             cls.print_issue_summary(pull)

--- a/relnotes/pull-base.bug.md
+++ b/relnotes/pull-base.bug.md
@@ -1,0 +1,5 @@
+### Check if the base branch exists when creating a PR (#92)
+
+When creating a PR if the specified (or inferred) base branch doesn't exist,
+a very weird error message was printed. Now the branch existence is explicitly
+checked before attempting the PR creation.


### PR DESCRIPTION
When creating a PR, we first query GitHub to check if the base branch
exists, and show a more meaningful error when it doesn't.

Fixes #92.