### PR TITLE
README: Update Debian badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,8 +2,8 @@
 A Git command line interface to GitHub
 ======================================
 
-.. image:: https://img.shields.io/debian/v/git-hub
-   :target: https://packages.debian.org/source/buster/git-hub
+.. image:: https://img.shields.io/debian/v/git-hub/unstable
+   :target: https://packages.debian.org/source/unstable/git-hub
    :alt: Debian package
 
 .. contents::

--- a/relnotes/typos.bug.md
+++ b/relnotes/typos.bug.md
@@ -1,3 +1,0 @@
-### Fix typos
-
-Some typos in the output and man page were fixed.


### PR DESCRIPTION
Point explicitly to unstable, as we want to show the latest version.

Also remove old release notes.