### PR TITLE
Remove unused import

### DIFF
--- a/git-hub
+++ b/git-hub
@@ -43,7 +43,6 @@ import re
 import sys
 import time
 import json
-import base64
 import pprint
 import urllib.request, urllib.error, urllib.parse
 import getpass


### PR DESCRIPTION
The only use of the `base64` module was removed in b1de325f5682b643a88834dd3862509e82030569.

Found using pyflakes.