### PR TITLE
Fix error reading template from path

### DIFF
--- a/git-hub
+++ b/git-hub
@@ -1125,7 +1125,7 @@ class IssueUtil (object):
         template = None
         for d, f in ((d, f) for d in directories for f in template_names):
             path = os.path.join(d, f)
-            if os.path.exists(path):
+            if os.path.isfile(path):
                 try:
                     file = open(path, "r")
                     template = file.read()

--- a/relnotes/issue-310.bug.md
+++ b/relnotes/issue-310.bug.md
@@ -1,0 +1,6 @@
+### Fix error reading template from path
+
+Verify the template is a regular file so that the content of the template
+can be added to the message of the issue or pull request.
+The current implementation of templates does not support directories of
+templates.


### PR DESCRIPTION
Verify the template is a regular file so that the content of the template can be added to the message of the issue or pull request.

Fixes #310