### PR TITLE
Fix pull new broken by #306

### DIFF
--- a/git-hub
+++ b/git-hub
@@ -1287,11 +1287,6 @@ class IssueCmd (CmdGroup):
                     "number ID to the %s" % cls.name)
         @classmethod
         def run(cls, parser, args):
-            # URL fixed to issues, pull requests updates are made
-            # through issues to allow changing labels, assignee and
-            # milestone (even when GitHub itself doesn't support it
-            # :D)
-            url = '/repos/%s/issues/%s' % (config.upstream, args.issue)
             title_body = dict()
             msg = args.message
             title = args.title
@@ -1299,7 +1294,7 @@ class IssueCmd (CmdGroup):
                 title_body['title'] = title
             if args.edit_message:
                 if not msg:
-                    issue = req.get(url)
+                    issue = req.get(cls.url(args.issue))
                     msg = title if title else issue['title']
                     if issue['body']:
                         msg += '\n\n' + issue['body']
@@ -1308,11 +1303,14 @@ class IssueCmd (CmdGroup):
                 (title, body) = split_titled_message(msg)
                 title_body['title'] = title
                 title_body['body'] = body
-            issue = cls._do_update(url, args.labels, args.assignee,
-                    args.milestone, args.state, **title_body)
-            cls.print_issue_summary(issue)
+            issue = cls._do_update(args.issue, args.labels,
+                    args.assignee, args.milestone, args.state, **title_body)
+            if issue is None:
+                infof('Nothing to update for #{}', args.issue)
+            else:
+                cls.print_issue_summary(issue)
         @classmethod
-        def _do_update(cls, url, labels=None, assignee=None,
+        def _do_update(cls, issue_num, labels=None, assignee=None,
                 milestone=None, state=None, title=None, body=None):
             params = dict()
             # Should labels be cleared?
@@ -1330,7 +1328,12 @@ class IssueCmd (CmdGroup):
                 params['title'] = title
             if body:
                 params['body'] = body
-            return req.patch(url, **params)
+            if not params:
+                return None  # Make sure we don't make an invalid empty request
+            # The URL is "hardcoded" to the issue URL here because the GitHub
+            # API allows updating some metadata (like assignee, milestone and
+            # labels), through it.
+            return req.patch(IssueUtil.url(issue_num), **params)
 
     class CommentCmd (IssueUtil):
         cmd_help = "add a comment to an existing issue"


### PR DESCRIPTION
When fixing #306, the pull new command was broken as it wasn't adapted
to use the new _do_update().

This is an example traceback shown by pull new:

Pushing v2.x.x to branch in fork
Creating pull request from branch branch to sociomantic-tsunami/git-hub:v2.x.x
Traceback (most recent call last):
  File "./git-hub", line 2254, in <module>
    main()
  File "./git-hub", line 2246, in main
    args.run(parser, args)
  File "./git-hub", line 683, in check_config_and_run
    cmd.run(parser, args)
  File "./git-hub", line 1574, in run
    IssueCmd.UpdateCmd._do_update(pull['number'], args.labels,
  File "./git-hub", line 1333, in _do_update
    return req.patch(url, **params)
  File "./git-hub", line 525, in <lambda>
    self.json_req(url, method, media_type, *args, **kwargs)
  File "./git-hub", line 490, in json_req
    url = self.base_url + url
TypeError: can only concatenate str (not "int") to str

We revert back to somehow hardcoding the URL used in _do_update()
because some issue/PR metadata can be updated in GH only using the
issues API endpoint.