### PR TITLE
Update actions dependencies and enable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "semiannually"
+    labels:
+      - "tech-debt"
+    groups:
+      compatible:
+        update-types:
+          - "minor"
+          - "patch"
+      artifacts:
+        patterns:
+          - "actions/*-artifact"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0  # Needed to make sure to proper git describe
       # This is a workaround for https://github.com/actions/checkout/issues/649
@@ -21,7 +21,7 @@ jobs:
       - name: Build
         run: make PYTHON=python3 all deb
       - name: Archive package artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: deb
           path: deb/git-hub_*.deb

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,10 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get -y install python3 python-docutils ruby-dev
+          sudo apt-get -y install python3 ruby-dev
           sudo gem install fpm
+          python3 -m pip install --upgrade pip
+          python3 -m pip install docutils
       - name: Build
         run: make PYTHON=python3 all deb
       - name: Archive package artifacts


### PR DESCRIPTION
- **Update deprecated actions in CI workflow**
- **Add dependabot configuration to update GitHub Actions**
